### PR TITLE
correction to stripe price from cents to dollars

### DIFF
--- a/src/server/api/products.js
+++ b/src/server/api/products.js
@@ -46,7 +46,7 @@ router.post('/', verify, async (req, res, next) => {
     })
     const stripePrice = await stripe.prices.create({
       currency: 'usd',
-      unit_amount: price,
+      unit_amount: (price * 100),
       product: stripeProduct.id,
     });
 


### PR DESCRIPTION
The original stripe price was in cents and needed to be multiplied by 100 to get dollars.